### PR TITLE
added system monitor keybind for `btop`

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -159,6 +159,7 @@ bind = SUPER, E, exec, thunar
 bind = SUPER, D, exec, killall rofi || rofi -show drun -theme ~/.config/rofi/global/rofi.rasi
 bind = SUPER, period, exec, killall rofi || rofi -show emoji -emoji-format "{emoji}" -modi emoji -theme ~/.config/rofi/global/emoji
 bind = SUPER, escape, exec, wlogout --protocol layer-shell -b 5 -T 400 -B 400
+bind = SUPER, H , exec, wezterm start btop #system monitor keybind `btop`
 
 # █░█░█ █ █▄░█ █▀▄ █▀█ █░█░█   █▀▄▀█ ▄▀█ █▄░█ ▄▀█ █▀▀ █▀▄▀█ █▀▀ █▄░█ ▀█▀
 # ▀▄▀▄▀ █ █░▀█ █▄▀ █▄█ ▀▄▀▄▀   █░▀░█ █▀█ █░▀█ █▀█ █▄█ █░▀░█ ██▄ █░▀█ ░█░


### PR DESCRIPTION
Resource monitor that shows usage and stats for processor, memory, disks, network and processes.

![image](https://user-images.githubusercontent.com/109201315/217748659-96cdb053-4301-4b8f-9574-1b024fca3099.png)
