### PR TITLE
Fix: removed empty space in playerctl in waybar

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -48,8 +48,8 @@
       "on-click": "playerctl previous",
       "on-click-right": "playerctl next",
       "format-icons": {
-        "Playing": "<span foreground='#E5B9C6'>󰒮 󰐌  󰒭</span>",
-        "Paused": "<span foreground='#928374'>󰒮 󰏥  󰒭</span>"
+        "Playing": "<span foreground='#E5B9C6'>󰒮 󰐌 󰒭</span>",
+        "Paused": "<span foreground='#928374'>󰒮 󰏥 󰒭</span>"
       },
     },
 
@@ -62,8 +62,8 @@
       "on-click": "playerctl previous",
       "on-click-right": "playerctl next",
       "format-icons": {
-        "Playing": "<span foreground='#E5B9C6'>󰒮 󰐌  󰒭</span>",
-        "Paused": "<span foreground='#928374'>󰒮 󰏥  󰒭</span>"
+        "Playing": "<span foreground='#E5B9C6'>󰒮 󰐌 󰒭</span>",
+        "Paused": "<span foreground='#928374'>󰒮 󰏥 󰒭</span>"
       },
     },
 


### PR DESCRIPTION
Hi, just fixed the playerctl item in waybar. 
You can also see it on your screenshots. There is a slight offset. 