### PR TITLE
Fix: blur error on new version

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -90,12 +90,14 @@ decoration {
 
   # █▄▄ █░░ █░█ █▀█
   # █▄█ █▄▄ █▄█ █▀▄
-  blur = true
-  blur_size = 6
-  blur_passes = 3
-  blur_new_optimizations = true
-  blur_xray = true
-  blur_ignore_opacity = true
+  blur {
+    enabled = true
+    size = 6
+    passes = 3
+    new_optimizations = true
+    xray = true
+    ignore_opacity = true
+  }
 
   # █▀ █░█ ▄▀█ █▀▄ █▀█ █░█░█
   # ▄█ █▀█ █▀█ █▄▀ █▄█ ▀▄▀▄▀


### PR DESCRIPTION
The blur configuration has changed on version 0.28.0.

https://github.com/hyprwm/Hyprland/releases/tag/v0.28.0

https://wiki.hyprland.org/Configuring/Variables/#blur